### PR TITLE
vim-migemoプラグインの改善

### DIFF
--- a/autoload/migemo.vim
+++ b/autoload/migemo.vim
@@ -53,17 +53,18 @@ function! s:SearchDict2(name)
 endfunction
 
 function! s:SearchDict()
-  let dict = ''
-  if dict == ''
-    let dict = s:SearchDict2('migemo/'.&encoding.'/migemo-dict')
-  endif
-  if dict == ''
-    let dict = s:SearchDict2(&encoding.'/migemo-dict')
-  endif
-  if dict == ''
-    let dict = s:SearchDict2('migemo-dict')
-  endif
-  return dict
+  for path in [
+        \ 'migemo/'.&encoding.'/migemo-dict',
+        \ &encoding.'/migemo-dict',
+        \ 'migemo-dict',
+        \ ]
+    let dict = s:SearchDict2(path)
+    if dict != ''
+      return dict
+    endif
+  endfor
+  echoerr 'a dictionary for migemo is not found'
+  echoerr 'your encoding is '.&encoding
 endfunction
 
 if has('migemo')

--- a/autoload/migemo.vim
+++ b/autoload/migemo.vim
@@ -3,10 +3,11 @@
 " migemo.vim
 "   Direct search for Japanese with Romaji --- Migemo support script.
 "
-" Maintainer:  MURAOKA Taro <koron@tka.att.ne.jp>
-" Modified:    Yasuhiro Matsumoto <mattn_jp@hotmail.com>
-" Last Change: 22 Dec 2013.
-"
+" Maintainer:   haya14busa <hayabusa1419@gmail.com>
+" Original:     MURAOKA Taro <koron.kaoriya@gmail.com>
+" Contributors: Yasuhiro Matsumoto <mattn_jp@hotmail.com>
+" Last Change: 23 Dec 2013.
+
 let s:save_cpo = &cpo
 set cpo&vim
 

--- a/autoload/migemo.vim
+++ b/autoload/migemo.vim
@@ -81,7 +81,10 @@ if has('migemo')
   endfunction
 else
   " non-builtin version
-  let g:migemodict = s:SearchDict()
+  if g:migemodict ==# ''
+    let g:migemodict = s:SearchDict()
+  endif
+
   function! migemo#MigemoSearch(word)
     if executable('cmigemo') == ''
       echohl ErrorMsg
@@ -101,7 +104,7 @@ else
 
     let @/ = retval
     let v:errmsg = ''
-    silent! normal n
+    silent! normal! n
     if v:errmsg != ''
       echohl ErrorMsg
       echo v:errmsg

--- a/autoload/migemo.vim
+++ b/autoload/migemo.vim
@@ -1,0 +1,96 @@
+" vim:set ts=8 sts=2 sw=2 tw=0:
+"
+" migemo.vim
+"   Direct search for Japanese with Romaji --- Migemo support script.
+"
+" Maintainer:  MURAOKA Taro <koron@tka.att.ne.jp>
+" Modified:    Yasuhiro Matsumoto <mattn_jp@hotmail.com>
+" Last Change: 22 Dec 2013.
+"
+let s:save_cpo = &cpo
+set cpo&vim
+
+function! s:SearchDict2(name)
+  let path = $VIM . ',' . &runtimepath
+  let dict = globpath(path, "dict/".a:name)
+  if dict == ''
+    let dict = globpath(path, a:name)
+  endif
+  if dict == ''
+    for path in [
+          \ '/usr/local/share/migemo/',
+          \ '/usr/local/share/cmigemo/',
+          \ '/usr/local/share/',
+          \ '/usr/share/cmigemo/',
+          \ '/usr/share/',
+          \ ]
+      let path = path . a:name
+      if filereadable(path)
+        let dict = path
+        break
+      endif
+    endfor
+  endif
+  let dict = matchstr(dict, "^[^\<NL>]*")
+  return dict
+endfunction
+
+function! s:SearchDict()
+  let dict = ''
+  if dict == ''
+    let dict = s:SearchDict2('migemo/'.&encoding.'/migemo-dict')
+  endif
+  if dict == ''
+    let dict = s:SearchDict2(&encoding.'/migemo-dict')
+  endif
+  if dict == ''
+    let dict = s:SearchDict2('migemo-dict')
+  endif
+  return dict
+endfunction
+
+if has('migemo')
+  if &migemodict == '' || !filereadable(&migemodict)
+    let &migemodict = s:SearchDict()
+  endif
+
+  " eXg
+  function! migemo#SearchChar(dir)
+    let input = nr2char(getchar())
+    let pat = migemo(input)
+    call search('\%(\%#.\{-\}\)\@<='.pat)
+    noh
+  endfunction
+else
+  " non-builtin version
+  let g:migemodict = s:SearchDict()
+  function! migemo#MigemoSearch(word)
+    if executable('cmigemo') == ''
+      echohl ErrorMsg
+      echo 'Error: cmigemo is not installed'
+      echohl None
+      return
+    endif
+
+    let retval = a:word != '' ? a:word : input('MIGEMO:')
+    if retval == ''
+      return
+    endif
+    let retval = system('cmigemo -v -w "'.retval.'" -d "'.g:migemodict.'"')
+    if retval == ''
+      return
+    endif
+
+    let @/ = retval
+    let v:errmsg = ''
+    silent! normal n
+    if v:errmsg != ''
+      echohl ErrorMsg
+      echo v:errmsg
+      echohl None
+    endif
+  endfunction
+endif
+
+let &cpo = s:save_cpo
+unlet s:save_cpo

--- a/autoload/migemo.vim
+++ b/autoload/migemo.vim
@@ -10,6 +10,23 @@
 let s:save_cpo = &cpo
 set cpo&vim
 
+function! s:has_vimproc()
+    if !exists('s:exists_vimproc')
+        try
+            silent call vimproc#version()
+            let s:exists_vimproc = 1
+        catch
+            let s:exists_vimproc = 0
+        endtry
+    endif
+
+    return s:exists_vimproc
+endfunction
+
+function! migemo#system(...)
+    return call(s:has_vimproc() ? 'vimproc#system' : 'system', a:000)
+endfunction
+
 function! s:SearchDict2(name)
   let path = $VIM . ',' . &runtimepath
   let dict = globpath(path, "dict/".a:name)
@@ -76,7 +93,7 @@ else
     if retval == ''
       return
     endif
-    let retval = system('cmigemo -v -w "'.retval.'" -d "'.g:migemodict.'"')
+    let retval =  migemo#system('cmigemo -v -w "'.retval.'" -d "'.g:migemodict.'"')
     if retval == ''
       return
     endif

--- a/autoload/migemo.vim
+++ b/autoload/migemo.vim
@@ -11,16 +11,16 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 function! s:has_vimproc()
-    if !exists('s:exists_vimproc')
-        try
-            silent call vimproc#version()
-            let s:exists_vimproc = 1
-        catch
-            let s:exists_vimproc = 0
-        endtry
-    endif
+  if !exists('s:exists_vimproc')
+    try
+      silent call vimproc#version()
+      let s:exists_vimproc = 1
+    catch
+      let s:exists_vimproc = 0
+    endtry
+  endif
 
-    return s:exists_vimproc
+  return s:exists_vimproc
 endfunction
 
 function! migemo#system(...)

--- a/plugin/migemo.vim
+++ b/plugin/migemo.vim
@@ -16,6 +16,8 @@ endif
 let s:save_cpo = &cpo
 set cpo&vim
 
+let g:migemodict = get(g:, 'migemodict', '')
+
 if has('migemo')
   nnoremap <silent> <Plug>(migemo-searchchar) :call migemo#SearchChar(0)<CR>
   if !hasmapto('<Plug>(migemo-searchchar)') && empty(maparg('<Leader>f', 'n'))

--- a/plugin/migemo.vim
+++ b/plugin/migemo.vim
@@ -5,7 +5,7 @@
 "
 " Maintainer:  MURAOKA Taro <koron@tka.att.ne.jp>
 " Modified:    Yasuhiro Matsumoto <mattn_jp@hotmail.com>
-" Last Change: 15-Dec-2013.
+" Last Change: 22 Dec 2013.
 
 " Japanese Description:
 
@@ -16,91 +16,12 @@ endif
 let s:save_cpo = &cpo
 set cpo&vim
 
-function! s:SearchDict2(name)
-  let path = $VIM . ',' . &runtimepath
-  let dict = globpath(path, "dict/".a:name)
-  if dict == ''
-    let dict = globpath(path, a:name)
-  endif
-  if dict == ''
-    for path in [
-          \ '/usr/local/share/migemo/',
-          \ '/usr/local/share/cmigemo/',
-          \ '/usr/local/share/',
-          \ '/usr/share/cmigemo/',
-          \ '/usr/share/',
-          \ ]
-      let path = path . a:name
-      if filereadable(path)
-        let dict = path
-        break
-      endif
-    endfor
-  endif
-  let dict = matchstr(dict, "^[^\<NL>]*")
-  return dict
-endfunction
-
-function! s:SearchDict()
-  let dict = ''
-  if dict == ''
-    let dict = s:SearchDict2('migemo/'.&encoding.'/migemo-dict')
-  endif
-  if dict == ''
-    let dict = s:SearchDict2(&encoding.'/migemo-dict')
-  endif
-  if dict == ''
-    let dict = s:SearchDict2('migemo-dict')
-  endif
-  return dict
-endfunction
-
 if has('migemo')
-  if &migemodict == '' || !filereadable(&migemodict)
-    let &migemodict = s:SearchDict()
-  endif
-
-  " ƒeƒXƒg
-  function! s:SearchChar(dir)
-    let input = nr2char(getchar())
-    let pat = migemo(input)
-    call search('\%(\%#.\{-\}\)\@<='.pat)
-    noh
-  endfunction
-  nnoremap <Leader>f :call <SID>SearchChar(0)<CR>
+  nnoremap <Leader>f :call migemo#SearchChar(0)<CR>
 else
-  " non-builtin version
-  let g:migemodict = s:SearchDict()
-  command! -nargs=* Migemo :call <SID>MigemoSearch(<q-args>)
-  nnoremap <silent> <leader>mi :call <SID>MigemoSearch('')<cr>
-
-  function! s:MigemoSearch(word)
-    if executable('cmigemo') == ''
-      echohl ErrorMsg
-      echo 'Error: cmigemo is not installed'
-      echohl None
-      return
-    endif
-  
-    let retval = a:word != '' ? a:word : input('MIGEMO:')
-    if retval == ''
-      return
-    endif
-    let retval = system('cmigemo -v -w "'.retval.'" -d "'.g:migemodict.'"')
-    if retval == ''
-      return
-    endif
-  
-    let @/ = retval
-    let v:errmsg = ''
-    silent! normal n
-    if v:errmsg != ''
-      echohl ErrorMsg
-      echo v:errmsg
-      echohl None
-    endif
-  endfunction
-endif
+  command! -nargs=* Migemo call migemo#MigemoSearch(<q-args>)
+  nnoremap <silent> <leader>mi :call migemo#MigemoSearch('')<cr>
+endi
 
 let &cpo = s:save_cpo
 unlet s:save_cpo

--- a/plugin/migemo.vim
+++ b/plugin/migemo.vim
@@ -3,9 +3,10 @@
 " migemo.vim
 "   Direct search for Japanese with Romaji --- Migemo support script.
 "
-" Maintainer:  MURAOKA Taro <koron@tka.att.ne.jp>
-" Modified:    Yasuhiro Matsumoto <mattn_jp@hotmail.com>
-" Last Change: 22 Dec 2013.
+" Maintainer:   haya14busa <hayabusa1419@gmail.com>
+" Original:     MURAOKA Taro <koron.kaoriya@gmail.com>
+" Contributors: Yasuhiro Matsumoto <mattn_jp@hotmail.com>
+" Last Change: 23 Dec 2013.
 
 " Japanese Description:
 

--- a/plugin/migemo.vim
+++ b/plugin/migemo.vim
@@ -17,10 +17,16 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 if has('migemo')
-  nnoremap <Leader>f :call migemo#SearchChar(0)<CR>
+  nnoremap <silent> <Plug>(migemo-searchchar) :call migemo#SearchChar(0)<CR>
+  if !hasmapto('<Plug>(migemo-searchchar)') && empty(maparg('<Leader>f', 'n'))
+    nmap <silent> <Leader>f <Plug>(migemo-searchchar)
+  endif
 else
   command! -nargs=* Migemo call migemo#MigemoSearch(<q-args>)
-  nnoremap <silent> <leader>mi :call migemo#MigemoSearch('')<cr>
+  nnoremap <silent> <Plug>(migemo-migemosearch) :call migemo#MigemoSearch('')<CR>
+  if !hasmapto('<Plug>(migemo-migemosearch)') && empty(maparg('<Leader>mi', 'n'))
+    nmap <silent> <Leader>mi <Plug>(migemo-migemosearch)
+  endif
 endi
 
 let &cpo = s:save_cpo


### PR DESCRIPTION
hi @koron さん

autoloadにファイルを分けた関係で、cmigemoのディレクトリ構成に合わせてプルリクを作るのがしんどそうだったので、こちらのmasterにプルリクという形でお願いします。

リンクをcmigemoから貼ってもらってる関係上、こちらのmasterはcmigemoと一致させて、勝手にプッシュしないようにしているので,cmigemoのmigemo.vimと同じ状態です。
### 変更点
- `autoload/`に実装を逃して読み込み速度の改善
- conflictの可能性のあるマッピングの定義の仕方を改善。
  - 新たなマッピングも`<Plug>`でやりやすい
- vimprocが存在するときはvimprocを使用する
  - 非同期実行というだけでなくwindowsでDOS窓がでなくなる
- `s:SearchDict2()`の改善。(エラーメッセージの追加など)
- `g:migemodict`でmigemo辞書のパスを指定出来るように

仮にOKだとしてcmigemoにプルリクする際、以前のパスにシンボリックリンクを貼ってmigemo.vimをインストールしているという場合も考えられるので、どーしたものかなーと思います。

よろしくおねがいします。
